### PR TITLE
Skip all but the first test.

### DIFF
--- a/bowling/bowling_test.php
+++ b/bowling/bowling_test.php
@@ -25,6 +25,7 @@ class GameTest extends \PHPUnit_Framework_TestCase
 
     public function testAllOnes()
     {
+        $this->markTestSkipped();
         $this->rollMany(20, 1);
 
         $this->assertEquals(20, $this->game->score());
@@ -32,6 +33,7 @@ class GameTest extends \PHPUnit_Framework_TestCase
 
     public function testOneSpare()
     {
+        $this->markTestSkipped();
         $this->rollSpare();
         $this->game->roll(3);
         $this->rollMany(17, 0);
@@ -41,6 +43,7 @@ class GameTest extends \PHPUnit_Framework_TestCase
 
     public function testOneStrike()
     {
+        $this->markTestSkipped();
         $this->rollStrike();
         $this->game->roll(3);
         $this->game->roll(4);
@@ -51,6 +54,7 @@ class GameTest extends \PHPUnit_Framework_TestCase
 
     public function testPerfectGame()
     {
+        $this->markTestSkipped();
         $this->rollMany(12, 10);
 
         $this->assertEquals(300, $this->game->score());

--- a/clock/clock_test.php
+++ b/clock/clock_test.php
@@ -13,6 +13,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testPastTheHour()
     {
+        $this->markTestSkipped();
         $clock = new Clock(11, 9);
 
         $this->assertEquals('11:09', $clock->__toString());
@@ -20,6 +21,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testAddingAFewMinutes()
     {
+        $this->markTestSkipped();
         $clock = new Clock(10);
 
         $clock = $clock->add(3);
@@ -29,6 +31,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testAddingOverAnHour()
     {
+        $this->markTestSkipped();
         $clock = new Clock(10);
 
         $clock = $clock->add(61);
@@ -38,6 +41,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testWrapAroundAtMidnight()
     {
+        $this->markTestSkipped();
         $clock = new Clock(23, 30);
 
         $clock = $clock->add(60);
@@ -47,6 +51,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testSubtractMinutes()
     {
+        $this->markTestSkipped();
         $clock = new Clock(10);
 
         $clock = $clock->sub(90);
@@ -56,6 +61,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testWrapAroundBackwards()
     {
+        $this->markTestSkipped();
         $clock = new Clock(0, 30);
 
         $clock = $clock->sub(60);
@@ -65,6 +71,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testWrapAroundDay()
     {
+        $this->markTestSkipped();
         $clock = new Clock(5, 32);
 
         $clock = $clock->add(25 * 60);
@@ -74,6 +81,7 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testWrapAroundDayBackwards()
     {
+        $this->markTestSkipped();
         $clock = new Clock(5, 32);
 
         $clock = $clock->sub(25 * 60);
@@ -83,11 +91,13 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function testEquivalentClocks()
     {
+        $this->markTestSkipped();
         $this->assertEquals(new Clock(15, 37), new Clock(15, 37));
     }
 
     public function testInequivalentClocks()
     {
+        $this->markTestSkipped();
         $this->assertNotEquals(new Clock(01, 01), new Clock(18, 32));
     }
 }

--- a/connect/connect_test.php
+++ b/connect/connect_test.php
@@ -31,6 +31,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testOneByOneBoardBlack()
     {
+        $this->markTestSkipped();
         $lines = array("X");
         $this->assertEquals("black", resultFor($this->makeBoard($lines)));
     }
@@ -40,6 +41,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testOneByOneBoardWhite()
     {
+        $this->markTestSkipped();
         $lines = array("O");
         $this->assertEquals("white", resultFor($this->makeBoard($lines)));
     }
@@ -50,6 +52,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testConvultedPath()
     {
+        $this->markTestSkipped();
         $lines = array(
             ". X X . .",
             " X . X . X",
@@ -65,6 +68,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testRectangleWhiteWins()
     {
+        $this->markTestSkipped();
         $lines = array(
             ". O . .",
             " O X X X",
@@ -80,6 +84,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testRectangleBlackWins()
     {
+        $this->markTestSkipped();
         $lines = array(
             ". O . .",
             " O X X X",
@@ -96,6 +101,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSpiralBlackWins()
     {
+        $this->markTestSkipped();
         $lines = array(
             "OXXXXXXXX",
             "OXOOOOOOO",
@@ -116,6 +122,7 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
      */
     public function testSpiralNobodyWins()
     {
+        $this->markTestSkipped();
         $lines = array(
             "OXXXXXXXX",
             "OXOOOOOOO",

--- a/difference-of-squares/difference-of-squares_test.php
+++ b/difference-of-squares/difference-of-squares_test.php
@@ -11,41 +11,49 @@ class SquaresTest extends PHPUnit_Framework_TestCase
 
     public function testSumOfSquaresTo5()
     {
+        $this->markTestSkipped();
         $this->assertEquals(55, sumOfSquares(5));
     }
 
     public function testDifferenceOfSumsTo5()
     {
+        $this->markTestSkipped();
         $this->assertEquals(170, difference(5));
     }
 
     public function testSquareOfSumsTo10()
     {
+        $this->markTestSkipped();
         $this->assertEquals(3025, squareOfSums(10));
     }
 
     public function testSumOfSquaresTo10()
     {
+        $this->markTestSkipped();
         $this->assertEquals(385, sumOfSquares(10));
     }
 
     public function testDifferenceOfSumsTo10()
     {
+        $this->markTestSkipped();
         $this->assertEquals(2640, difference(10));
     }
 
     public function testSquareOfSumsTo100()
     {
+        $this->markTestSkipped();
         $this->assertEquals(25502500, squareOfSums(100));
     }
 
     public function testSumOfSquaresTo100()
     {
+        $this->markTestSkipped();
         $this->assertEquals(338350, sumOfSquares(100));
     }
 
     public function testDifferenceOfSumsTo100()
     {
+        $this->markTestSkipped();
         $this->assertEquals(25164150, difference(100));
     }
 }

--- a/gigasecond/gigasecond_test.php
+++ b/gigasecond/gigasecond_test.php
@@ -22,6 +22,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
     public function test2()
     {
+        $this->markTestSkipped();
         $date = GigasecondTest::dateSetup("1977-06-13");
         $gs = from($date);
 
@@ -30,6 +31,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
     public function test3()
     {
+        $this->markTestSkipped();
         $date = GigasecondTest::dateSetup("1959-7-19");
         $gs = from($date);
 
@@ -38,6 +40,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
     public function test4()
     {
+        $this->markTestSkipped();
         $date = GigasecondTest::dateSetup("2015-01-24 22:00:00");
         $gs = from($date);
 
@@ -46,6 +49,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
     public function test5()
     {
+        $this->markTestSkipped();
         $date = GigasecondTest::dateSetup("2015-01-24 23:59:59");
         $gs = from($date);
 

--- a/hamming/hamming_test.php
+++ b/hamming/hamming_test.php
@@ -12,36 +12,43 @@ class HammingComparatorTest extends PHPUnit_Framework_TestCase
 
     public function testCompleteHammingDistanceOfForSingleNucleotideStrand()
     {
+        $this->markTestSkipped();
         $this->assertEquals(1, distance('A', 'G'));
     }
 
     public function testCompleteHammingDistanceForSmallStrand()
     {
+        $this->markTestSkipped();
         $this->assertEquals(2, distance('AG', 'CT'));
     }
 
     public function testSmallHammingDistance()
     {
+        $this->markTestSkipped();
         $this->assertEquals(1, distance('AT', 'CT'));
     }
 
     public function testSmallHammingDistanceInLongerStrand()
     {
+        $this->markTestSkipped();
         $this->assertEquals(1, distance('GGACG', 'GGTCG'));
     }
 
     public function testLargeHammingDistance()
     {
+        $this->markTestSkipped();
         $this->assertEquals(4, distance('GATACA', 'GCATAA'));
     }
 
     public function testHammingDistanceInVeryLongStrand()
     {
+        $this->markTestSkipped();
         $this->assertEquals(9, distance('GGACGGATTCTG', 'AGGACGGATTCT'));
     }
 
     public function testExceptionThrownWhenStrandsAreDifferentLength()
     {
+        $this->markTestSkipped();
         $this->setExpectedException('InvalidArgumentException', 'DNA strands must be of equal length.');
         distance('GGACG', 'AGGACGTGG');
     }

--- a/leap/leap_test.php
+++ b/leap/leap_test.php
@@ -11,21 +11,25 @@ class YearTest extends \PHPUnit_Framework_TestCase
 
     public function testNonLeapYear()
     {
+        $this->markTestSkipped();
         $this->assertFalse(isLeap(1997));
     }
 
     public function testNonLeapEvenYear()
     {
+        $this->markTestSkipped();
         $this->assertFalse(isLeap(1998));
     }
 
     public function testCentury()
     {
+        $this->markTestSkipped();
         $this->assertFalse(isLeap(1900));
     }
 
     public function testFourthCentury()
     {
+        $this->markTestSkipped();
         $this->assertTrue(isLeap(2400));
     }
 }

--- a/raindrops/raindrops_test.php
+++ b/raindrops/raindrops_test.php
@@ -11,71 +11,85 @@ class RaindropsTest extends PHPUnit_Framework_TestCase
 
     public function test3()
     {
+        $this->markTestSkipped();
         $this->assertSame("Pling", raindrops(3));
     }
 
     public function test5()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plang", raindrops(5));
     }
 
     public function test7()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plong", raindrops(7));
     }
 
     public function test6()
     {
+        $this->markTestSkipped();
         $this->assertSame("Pling", raindrops(6));
     }
 
     public function test10()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plang", raindrops(10));
     }
 
     public function test14()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plong", raindrops(14));
     }
 
     public function test15()
     {
+        $this->markTestSkipped();
         $this->assertSame("PlingPlang", raindrops(15));
     }
 
     public function test21()
     {
+        $this->markTestSkipped();
         $this->assertSame("PlingPlong", raindrops(21));
     }
 
     public function test25()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plang", raindrops(25));
     }
 
     public function test35()
     {
+        $this->markTestSkipped();
         $this->assertSame("PlangPlong", raindrops(35));
     }
 
     public function test49()
     {
+        $this->markTestSkipped();
         $this->assertSame("Plong", raindrops(49));
     }
 
     public function test52()
     {
+        $this->markTestSkipped();
         $this->assertSame("52", raindrops(52));
     }
 
     public function test105()
     {
+        $this->markTestSkipped();
         $this->assertSame("PlingPlangPlong", raindrops(105));
     }
 
     public function test12121()
     {
+        $this->markTestSkipped();
         $this->assertSame("12121", raindrops(12121));
     }
 }

--- a/rna-transcription/rna-transcription_test.php
+++ b/rna-transcription/rna-transcription_test.php
@@ -11,21 +11,25 @@ class ComplementTest extends \PHPUnit_Framework_TestCase
 
     public function testTranscribesCytosineToGuanine()
     {
+        $this->markTestSkipped();
         $this->assertSame('C', toRna('G'));
     }
 
     public function testTranscribesThymineToAdenine()
     {
+        $this->markTestSkipped();
         $this->assertSame('A', toRna('T'));
     }
 
     public function testTranscribesAdenineToUracil()
     {
+        $this->markTestSkipped();
         $this->assertSame('U', toRna('A'));
     }
 
     public function testTranscribesAllOccurencesOne()
     {
+        $this->markTestSkipped();
         $this->assertSame('UGCACCAGAAUU', toRna('ACGTGGTCTTAA'));
     }
 }

--- a/robot-name/robot-name_test.php
+++ b/robot-name/robot-name_test.php
@@ -19,6 +19,7 @@ class RobotTest extends PHPUnit_Framework_TestCase
 
     public function testNameSticks()
     {
+        $this->markTestSkipped();
         $old = $this->robot->getName();
 
         $this->assertSame($this->robot->getName(), $old);
@@ -26,6 +27,7 @@ class RobotTest extends PHPUnit_Framework_TestCase
 
     public function testDifferentRobotsHaveDifferentNames()
     {
+        $this->markTestSkipped();
         $other_bot = new Robot();
 
         $this->assertNotSame($other_bot->getName(), $this->robot->getName());
@@ -35,6 +37,7 @@ class RobotTest extends PHPUnit_Framework_TestCase
 
     public function testresetName()
     {
+        $this->markTestSkipped();
         $name1 = $this->robot->getName();
 
         $this->robot->reset();

--- a/roman-numerals/roman-numerals_test.php
+++ b/roman-numerals/roman-numerals_test.php
@@ -11,101 +11,121 @@ class RomanTest extends PHPUnit_Framework_TestCase
 
     public function test2()
     {
+        $this->markTestSkipped();
         $this->assertSame('II', toRoman(2));
     }
 
     public function test3()
     {
+        $this->markTestSkipped();
         $this->assertSame('III', toRoman(3));
     }
 
     public function test4()
     {
+        $this->markTestSkipped();
         $this->assertSame('IV', toRoman(4));
     }
 
     public function test5()
     {
+        $this->markTestSkipped();
         $this->assertSame('V', toRoman(5));
     }
 
     public function test6()
     {
+        $this->markTestSkipped();
         $this->assertSame('VI', toRoman(6));
     }
 
     public function test9()
     {
+        $this->markTestSkipped();
         $this->assertSame('IX', toRoman(9));
     }
 
     public function test27()
     {
+        $this->markTestSkipped();
         $this->assertSame('XXVII', toRoman(27));
     }
 
     public function test48()
     {
+        $this->markTestSkipped();
         $this->assertSame('XLVIII', toRoman(48));
     }
 
     public function test49()
     {
+        $this->markTestSkipped();
         $this->assertSame('XLIX', toRoman(49));
     }
 
     public function test59()
     {
+        $this->markTestSkipped();
         $this->assertSame('LIX', toRoman(59));
     }
 
     public function test93()
     {
+        $this->markTestSkipped();
         $this->assertSame('XCIII', toRoman(93));
     }
 
     public function test141()
     {
+        $this->markTestSkipped();
         $this->assertSame('CXLI', toRoman(141));
     }
 
     public function test163()
     {
+        $this->markTestSkipped();
         $this->assertSame('CLXIII', toRoman(163));
     }
 
     public function test402()
     {
+        $this->markTestSkipped();
         $this->assertSame('CDII', toRoman(402));
     }
 
     public function test575()
     {
+        $this->markTestSkipped();
         $this->assertSame('DLXXV', toRoman(575));
     }
 
     public function test911()
     {
+        $this->markTestSkipped();
         $this->assertSame('CMXI', toRoman(911));
     }
 
     public function test1024()
     {
+        $this->markTestSkipped();
         $this->assertSame('MXXIV', toRoman(1024));
     }
 
     public function test2014()
     {
+        $this->markTestSkipped();
         $this->assertSame('MCMXCVIII', toRoman(1998));
     }
 
     public function test2999()
     {
+        $this->markTestSkipped();
         $this->assertSame('MMCMXCIX', toRoman(2999));
     }
 
     public function test3000()
     {
+        $this->markTestSkipped();
         $this->assertSame('MMM', toRoman(3000));
     }
 }

--- a/trinary/trinary_test.php
+++ b/trinary/trinary_test.php
@@ -11,41 +11,49 @@ class TrinaryTest extends \PHPUnit_Framework_TestCase
 
     public function test2IsDecimal2()
     {
+        $this->markTestSkipped();
         $this->assertEquals(2, toDecimal('2'));
     }
 
     public function test10IsDecimal3()
     {
+        $this->markTestSkipped();
         $this->assertEquals(3, toDecimal('10'));
     }
 
     public function test11IsDecimal4()
     {
+        $this->markTestSkipped();
         $this->assertEquals(4, toDecimal('11'));
     }
 
     public function test100IsDecimal9()
     {
+        $this->markTestSkipped();
         $this->assertEquals(9, toDecimal('100'));
     }
 
     public function test112IsDecimal14()
     {
+        $this->markTestSkipped();
         $this->assertEquals(14, toDecimal('112'));
     }
 
     public function test222IsDecimal26()
     {
+        $this->markTestSkipped();
         $this->assertEquals(26, toDecimal('222'));
     }
 
     public function test1122000120IsDecimal32091()
     {
+        $this->markTestSkipped();
         $this->assertEquals(32091, toDecimal('1122000120'));
     }
 
     public function testInvalidTrinaryIsDecimal0()
     {
+        $this->markTestSkipped();
         $this->assertSame(0, toDecimal('13201'));
     }
 }

--- a/wordy/wordy_test.php
+++ b/wordy/wordy_test.php
@@ -11,71 +11,85 @@ class WordProblemTest extends \PHPUnit_Framework_TestCase
 
     public function testAdd2()
     {
+        $this->markTestSkipped();
         $this->assertEquals(55, calculate('What is 53 plus 2?'));
     }
 
     public function testAddNegativeNumbers()
     {
+        $this->markTestSkipped();
         $this->assertEquals(-11, calculate('What is -1 plus -10?'));
     }
 
     public function testAddMoreDigits()
     {
+        $this->markTestSkipped();
         $this->assertEquals(45801, calculate('What is 123 plus 45678?'));
     }
 
     public function testSubtract()
     {
+        $this->markTestSkipped();
         $this->assertEquals(16, calculate('What is 4 minus -12?'));
     }
 
     public function testMultiply()
     {
+        $this->markTestSkipped();
         $this->assertEquals(-75, calculate('What is -3 multiplied by 25?'));
     }
 
     public function testDivide()
     {
+        $this->markTestSkipped();
         $this->assertEquals(-11, calculate('What is 33 divided by -3?'));
     }
 
     public function testAddTwice()
     {
+        $this->markTestSkipped();
         $this->assertEquals(3, calculate('What is 1 plus 1 plus 1?'));
     }
 
     public function testAddThenSubtract()
     {
+        $this->markTestSkipped();
         $this->assertEquals(8, calculate('What is 1 plus 5 minus -2?'));
     }
 
     public function testSubtractTwice()
     {
+        $this->markTestSkipped();
         $this->assertEquals(3, calculate('What is 20 minus 4 minus 13?'));
     }
 
     public function testSubtractThenAdd()
     {
+        $this->markTestSkipped();
         $this->assertEquals(14, calculate('What is 17 minus 6 plus 3?'));
     }
 
     public function testMultiplyTwice()
     {
+        $this->markTestSkipped();
         $this->assertEquals(-12, calculate('What is 2 multiplied by -2 multiplied by 3?'));
     }
 
     public function testAddThenMultiply()
     {
+        $this->markTestSkipped();
         $this->assertEquals(-8, calculate('What is -3 plus 7 multiplied by -2?'));
     }
 
     public function testDivideTwice()
     {
+        $this->markTestSkipped();
         $this->assertEquals(2, calculate('What is -12 divided by 2 divided by -3?'));
     }
 
     public function testTooAdvanced()
     {
+        $this->markTestSkipped();
         $this->setExpectedException('InvalidArgumentException');
 
         calculate('What is 53 cubed?');
@@ -83,6 +97,7 @@ class WordProblemTest extends \PHPUnit_Framework_TestCase
 
     public function testIrrelevant()
     {
+        $this->markTestSkipped();
         $this->setExpectedException('InvalidArgumentException');
 
         calculate('Who is the president of the United States?');


### PR DESCRIPTION
By skipping the all but the first tests we

(1) Do not overwhelm the user with a bunch of failing tests.
(2) Are more in line with TDD development.

Setting up the tests as proposed would be in line with the way that the ruby
tests have been set up.