### PR TITLE
Fix make test not working in macosx.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,8 @@ bin/phpcs.phar:
 # single test
 test-assignment: bin/phpunit.phar
 	@echo "running tests for: $(ASSIGNMENT)"
-	@cp $(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)/$(TSTFILE)
+	@cat $(ASSIGNMENT)/$(TSTFILE) | sed '/markTestSkipped()/d' > $(OUTDIR)/$(TSTFILE)
 	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
-	@sed -i '/markTestSkipped/d' $(OUTDIR)/$(TSTFILE)
-	@sed -i 's/"your_birthday"/"2015-01-24 23:59:59"/' $(OUTDIR)/$(TSTFILE)
 	@bin/phpunit.phar --no-configuration $(OUTDIR)/$(TSTFILE)
 
 # all tests

--- a/gigasecond/gigasecond_test.php
+++ b/gigasecond/gigasecond_test.php
@@ -58,7 +58,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
     public function testYourself()
     {
-        $this->markTestSkipped();
+        $this->markTestSkipped("Skip");
         $your_birthday = GigasecondTest::dateSetup("your_birthday");
         $gs = from($your_birthday);
 


### PR DESCRIPTION
It turns out that sed -i in macosx works differently then on linux.
This commit uses a pipe to sed delete the skips avoiding -i
altogether.

Also, this commit adds the word "Skip" to a Gigasecond test that we do
want to be skipped.