### PR TITLE
Fix the robot-name test case including the example

### DIFF
--- a/robot-name/example.php
+++ b/robot-name/example.php
@@ -8,7 +8,7 @@ class Robot
 
     public function __construct()
     {
-        $this->alphabet = str_split('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        $this->alphabet = array_flip(str_split('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
     }
 
     public function getName()

--- a/robot-name/robot-name_test.php
+++ b/robot-name/robot-name_test.php
@@ -14,7 +14,7 @@ class RobotTest extends PHPUnit_Framework_TestCase
 
     public function testHasName()
     {
-        $this->assertRegExp('/\w{2}\d{3}/', $this->robot->getName());
+        $this->assertRegExp('/[a-z]{2}\d{3}/i', $this->robot->getName());
     }
 
     public function testNameSticks()

--- a/robot-name/robot-name_test.php
+++ b/robot-name/robot-name_test.php
@@ -14,7 +14,7 @@ class RobotTest extends PHPUnit_Framework_TestCase
 
     public function testHasName()
     {
-        $this->assertRegExp('/[a-z]{2}\d{3}/i', $this->robot->getName());
+        $this->assertRegExp('/^[a-z]{2}\d{3}$/i', $this->robot->getName());
     }
 
     public function testNameSticks()


### PR DESCRIPTION
I've fixed the testHasName().
It let really wired strings pass the test.
Also I've fixed the example to give valid names since it was generating 5 to 7 digit numbers as name (which were passing the wired test) .

