### PR TITLE
Ensure long diagonals don't count as adjacent

### DIFF
--- a/connect/connect_test.php
+++ b/connect/connect_test.php
@@ -136,4 +136,22 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(null, resultFor($this->makeBoard($lines)));
     }
+
+    /**
+     * @depends testSpiralBlackWins
+     * @depends testSpiralNobodyWins
+     */
+    public function testIllegalDiagonalNobodyWins()
+    {
+        $this->markTestSkipped();
+        $lines = array(
+            "X O . .",
+            " O X X X",
+            "  O X O .",
+            "   . O X .",
+            "    X X O O"
+        );
+
+        $this->assertEquals(null, resultFor($this->makeBoard($lines)));
+    }
 }


### PR DESCRIPTION
I noticed [one solution](http://exercism.io/submissions/59bd740ef4664d1eb5ac6ab9e35d8815) to the connect exercise that passed the test, but treated the board like a rectangular grid, counting "illegal" long diagonals as connections. This added test should catch those incorrect algorithms.