### PR TITLE
Force the gigasecond exercise to use a immutable version of Datetime

### DIFF
--- a/gigasecond/example.php
+++ b/gigasecond/example.php
@@ -1,6 +1,6 @@
 <?php
 
-function from(\DateTime $from)
+function from(\DateTimeImmutable $from)
 {
     $interval = new DateInterval("PT1000000000S");
     return $from->add($interval);

--- a/gigasecond/example.php
+++ b/gigasecond/example.php
@@ -1,7 +1,8 @@
 <?php
 
-function from(\DateTimeImmutable $from)
+function from(\DateTime $from)
 {
     $interval = new DateInterval("PT1000000000S");
-    return $from->add($interval);
+    $date = clone $from;
+    return $date->add($interval);
 }

--- a/gigasecond/gigasecond_test.php
+++ b/gigasecond/gigasecond_test.php
@@ -8,7 +8,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
     public function dateSetup($date)
     {
         $UTC = new DateTimeZone("UTC");
-        $date = new DateTimeImmutable($date, $UTC);
+        $date = new DateTime($date, $UTC);
         return $date;
     }
 

--- a/gigasecond/gigasecond_test.php
+++ b/gigasecond/gigasecond_test.php
@@ -8,7 +8,7 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
     public function dateSetup($date)
     {
         $UTC = new DateTimeZone("UTC");
-        $date = new DateTime($date, $UTC);
+        $date = new DateTimeImmutable($date, $UTC);
         return $date;
     }
 
@@ -54,6 +54,15 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
         $gs = from($date);
 
         $this->assertSame("2046-10-03 01:46:39", $gs->format("Y-m-d H:i:s"));
+    }
+
+    public function test6()
+    {
+        $this->markTestSkipped();
+        $date = GigasecondTest::dateSetup("2015-01-24");
+        $gs = from($date);
+
+        $this->assertNotEquals($date, $gs);
     }
 
     public function testYourself()


### PR DESCRIPTION
The current solution in the example has side effects.
```php
function from(\DateTime $from)
{
    $interval = new DateInterval("PT1000000000S");
    return $from->add($interval);
}
```

The `add` method not only returns a new `DateTime` but it also mutates `$from`.
Given that I would call this function twice with the same value.

```php
$date = new DateTime('1990-01-01');
from($date); // $date is now 2021-09-09
from($date); // $date is now 2053-05-18
```

This is clearly bad practice and is easily solved by using [DateTimeImmutable](http://php.net/manual/en/class.datetimeimmutable.php).