### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
+---
 language: php
-
 php:
-  - 5.6
-
+- 5.6
 script:
-  - make style-check
-  - make test
-  - ./bin/fetch-configlet
-  - ./bin/configlet .
+- make style-check
+- make test
+- "./bin/fetch-configlet"
+- "./bin/configlet ."


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.