### PR TITLE
Remove tests that require modification

### DIFF
--- a/exercises/gigasecond/gigasecond_test.php
+++ b/exercises/gigasecond/gigasecond_test.php
@@ -64,5 +64,4 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEquals($date, $gs);
     }
-
 }

--- a/exercises/gigasecond/gigasecond_test.php
+++ b/exercises/gigasecond/gigasecond_test.php
@@ -65,12 +65,4 @@ class GigasecondTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($date, $gs);
     }
 
-    public function testYourself()
-    {
-        $this->markTestSkipped("Skip");
-        $your_birthday = GigasecondTest::dateSetup("your_birthday");
-        $gs = from($your_birthday);
-
-        $this->assertSame("2046-10-03 01:46:39", $gs->format("Y-m-d H:i:s"));
-    }
 }


### PR DESCRIPTION
The test suite should not be modified in order for a test to pass. With the exception of skipped tests.