### PR TITLE
Add missing testcase for 9 (3 x 3) in raindrops ex

### DIFF
--- a/exercises/raindrops/raindrops_test.php
+++ b/exercises/raindrops/raindrops_test.php
@@ -33,6 +33,12 @@ class RaindropsTest extends PHPUnit_Framework_TestCase
         $this->assertSame("Pling", raindrops(6));
     }
 
+    public function test9()
+    {
+        $this->markTestSkipped();
+        $this->assertSame("Pling", raindrops(9));
+    }
+
     public function test10()
     {
         $this->markTestSkipped();


### PR DESCRIPTION
In Go, Javascript, Ruby, Rust tracks, this testcase is present.