### PR TITLE
instantiate classes, add test case

### DIFF
--- a/exercises/pig-latin/example.php
+++ b/exercises/pig-latin/example.php
@@ -30,4 +30,3 @@ function translateWord($str)
 
     return sprintf("%s%say", substr($str, 1), $str[0]);
 }
-

--- a/exercises/pig-latin/example.php
+++ b/exercises/pig-latin/example.php
@@ -1,36 +1,33 @@
 <?php
-
-class PigLatin
+/**
+ * Translates a string into Pig Latin
+ *
+ * @param  string $str
+ * @return string
+ */
+function translate($str)
 {
-    /**
-     * Translates a string into Pig Latin
-     *
-     * @param  string $str
-     * @return string
-     */
-    public static function translate($str)
-    {
-        $words = explode(" ", $str);
-        $translatedWords = array_map(["self", 'translateWord'], $words);
-        return implode(' ', $translatedWords);
-    }
-
-    /**
-     * Translates a single word
-     *
-     * @param  string $str
-     * @return string
-     */
-    private static function translateWord($str)
-    {
-        if (preg_match('/^s?qu|thr?|s?ch/', $str, $match)) {
-            return sprintf("%s%say", substr($str, strlen($match[0])), $match[0]);
-        }
-
-        if (preg_match('/^[aeiou]|yt|xr/', $str)) {
-            return sprintf("%say", $str);
-        }
-
-        return sprintf("%s%say", substr($str, 1), $str[0]);
-    }
+    $words = explode(" ", $str);
+    $translatedWords = array_map(["self", 'translateWord'], $words);
+    return implode(' ', $translatedWords);
 }
+
+/**
+ * Translates a single word
+ *
+ * @param  string $str
+ * @return string
+ */
+function translateWord($str)
+{
+    if (preg_match('/^s?qu|thr?|s?ch/', $str, $match)) {
+        return sprintf("%s%say", substr($str, strlen($match[0])), $match[0]);
+    }
+
+    if (preg_match('/^[aeiou]|yt|xr/', $str)) {
+        return sprintf("%say", $str);
+    }
+
+    return sprintf("%s%say", substr($str, 1), $str[0]);
+}
+

--- a/exercises/pig-latin/example.php
+++ b/exercises/pig-latin/example.php
@@ -8,7 +8,7 @@
 function translate($str)
 {
     $words = explode(" ", $str);
-    $translatedWords = array_map(["self", 'translateWord'], $words);
+    $translatedWords = array_map('translateWord', $words);
     return implode(' ', $translatedWords);
 }
 

--- a/exercises/pig-latin/pig-latin_test.php
+++ b/exercises/pig-latin/pig-latin_test.php
@@ -3,144 +3,150 @@ require_once "pig-latin.php";
 
 class PigLatinTest extends PHPUnit_Framework_TestCase
 {
+    protected $translator = null;
+
+    public function setUp()
+    {
+        $this->translator = new PigLatin();
+    }
+
     public function testWordBeginningWithP()
     {
-        $translator = new PigLatin();
-        $this->assertEquals("igpay", $translator->translate("pig"));
+        $this->assertEquals("igpay", $this->translator->translate("pig"));
     }
 
     public function testWordBeginningWithK()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("oalakay", $translator->translate("koala"));
+
+        $this->assertEquals("oalakay", $this->translator->translate("koala"));
     }
 
     public function testWordBeginningWithY()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("ellowyay", $translator->translate("yellow"));
+
+        $this->assertEquals("ellowyay", $this->translator->translate("yellow"));
     }
 
     public function testWordBeginningWithX()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("enonxay", $translator->translate("xenon"));
+
+        $this->assertEquals("enonxay", $this->translator->translate("xenon"));
     }
 
     public function testWordBeginningWithA()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("appleay", $translator->translate("apple"));
+
+        $this->assertEquals("appleay", $this->translator->translate("apple"));
     }
 
     public function testWordBeginningWithE()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("earay", $translator->translate("ear"));
+
+        $this->assertEquals("earay", $this->translator->translate("ear"));
     }
 
     public function testWordBeginningWithI()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("iglooay", $translator->translate("igloo"));
+
+        $this->assertEquals("iglooay", $this->translator->translate("igloo"));
     }
 
     public function testWordBeginningWithO()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("objectay", $translator->translate("object"));
+
+        $this->assertEquals("objectay", $this->translator->translate("object"));
     }
 
     public function testWordBeginningWithU()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("underay", $translator->translate("under"));
+
+        $this->assertEquals("underay", $this->translator->translate("under"));
     }
 
     public function testWordBeginningVowelFollowedByQu()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("equalay", $translator->translate("equal"));
+
+        $this->assertEquals("equalay", $this->translator->translate("equal"));
     }
 
 
     public function testWordBeginningWithQWithoutAFollowingU()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("atqay", $translator->translate("qat"));
+
+        $this->assertEquals("atqay", $this->translator->translate("qat"));
     }
 
 
     public function testWordBeginningWithCh()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("airchay", $translator->translate("chair"));
+
+        $this->assertEquals("airchay", $this->translator->translate("chair"));
     }
 
     public function testWordBeginningWithQu()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("eenquay", $translator->translate("queen"));
+
+        $this->assertEquals("eenquay", $this->translator->translate("queen"));
     }
 
     public function testWordBeginningWithQuAndAPrecedingConsonant()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("aresquay", $translator->translate("square"));
+
+        $this->assertEquals("aresquay", $this->translator->translate("square"));
     }
 
     public function testWordBeginningWithTh()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("erapythay", $translator->translate("therapy"));
+
+        $this->assertEquals("erapythay", $this->translator->translate("therapy"));
     }
 
     public function testWordBeginningWithThr()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("ushthray", $translator->translate("thrush"));
+
+        $this->assertEquals("ushthray", $this->translator->translate("thrush"));
     }
 
     public function testWordBeginningWithSch()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("oolschay", $translator->translate("school"));
+
+        $this->assertEquals("oolschay", $this->translator->translate("school"));
     }
 
     public function testWordBeginningWithYt()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("yttriaay", $translator->translate("yttria"));
+
+        $this->assertEquals("yttriaay", $this->translator->translate("yttria"));
     }
 
     public function testWordBeginningWithXr()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("xrayay", $translator->translate("xray"));
+
+        $this->assertEquals("xrayay", $this->translator->translate("xray"));
     }
 
     public function testAWholePhrase()
     {
         $this->markTestSkipped();
-        $translator = new PigLatin();
-        $this->assertEquals("ickquay astfay unray", $translator->translate("quick fast run"));
+
+        $this->assertEquals("ickquay astfay unray", $this->translator->translate("quick fast run"));
     }
 }

--- a/exercises/pig-latin/pig-latin_test.php
+++ b/exercises/pig-latin/pig-latin_test.php
@@ -5,134 +5,142 @@ class PigLatinTest extends PHPUnit_Framework_TestCase
 {
     public function testWordBeginningWithP()
     {
-        $this->assertEquals("igpay", PigLatin::translate("pig"));
+        $translator = new PigLatin();
+        $this->assertEquals("igpay", $translator->translate("pig"));
     }
 
     public function testWordBeginningWithK()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("oalakay", PigLatin::translate("koala"));
+        $translator = new PigLatin();
+        $this->assertEquals("oalakay", $translator->translate("koala"));
     }
 
     public function testWordBeginningWithY()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("ellowyay", PigLatin::translate("yellow"));
+        $translator = new PigLatin();
+        $this->assertEquals("ellowyay", $translator->translate("yellow"));
     }
 
     public function testWordBeginningWithX()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("enonxay", PigLatin::translate("xenon"));
+        $translator = new PigLatin();
+        $this->assertEquals("enonxay", $translator->translate("xenon"));
     }
 
     public function testWordBeginningWithA()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("appleay", PigLatin::translate("apple"));
+        $translator = new PigLatin();
+        $this->assertEquals("appleay", $translator->translate("apple"));
     }
 
     public function testWordBeginningWithE()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("earay", PigLatin::translate("ear"));
+        $translator = new PigLatin();
+        $this->assertEquals("earay", $translator->translate("ear"));
     }
 
     public function testWordBeginningWithI()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("iglooay", PigLatin::translate("igloo"));
+        $translator = new PigLatin();
+        $this->assertEquals("iglooay", $translator->translate("igloo"));
     }
 
     public function testWordBeginningWithO()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("objectay", PigLatin::translate("object"));
+        $translator = new PigLatin();
+        $this->assertEquals("objectay", $translator->translate("object"));
     }
 
     public function testWordBeginningWithU()
     {
         $this->markTestSkipped();
+        $translator = new PigLatin();
+        $this->assertEquals("underay", $translator->translate("under"));
+    }
 
-        $this->assertEquals("underay", PigLatin::translate("under"));
+    public function testWordBeginningVowelFollowedByQu()
+    {
+        $this->markTestSkipped();
+        $translator = new PigLatin();
+        $this->assertEquals("equalay", $translator->translate("equal"));
     }
 
 
     public function testWordBeginningWithQWithoutAFollowingU()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("atqay", PigLatin::translate("qat"));
+        $translator = new PigLatin();
+        $this->assertEquals("atqay", $translator->translate("qat"));
     }
 
 
     public function testWordBeginningWithCh()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("airchay", PigLatin::translate("chair"));
+        $translator = new PigLatin();
+        $this->assertEquals("airchay", $translator->translate("chair"));
     }
 
     public function testWordBeginningWithQu()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("eenquay", PigLatin::translate("queen"));
+        $translator = new PigLatin();
+        $this->assertEquals("eenquay", $translator->translate("queen"));
     }
 
     public function testWordBeginningWithQuAndAPrecedingConsonant()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("aresquay", PigLatin::translate("square"));
+        $translator = new PigLatin();
+        $this->assertEquals("aresquay", $translator->translate("square"));
     }
 
     public function testWordBeginningWithTh()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("erapythay", PigLatin::translate("therapy"));
+        $translator = new PigLatin();
+        $this->assertEquals("erapythay", $translator->translate("therapy"));
     }
 
     public function testWordBeginningWithThr()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("ushthray", PigLatin::translate("thrush"));
+        $translator = new PigLatin();
+        $this->assertEquals("ushthray", $translator->translate("thrush"));
     }
 
     public function testWordBeginningWithSch()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("oolschay", PigLatin::translate("school"));
+        $translator = new PigLatin();
+        $this->assertEquals("oolschay", $translator->translate("school"));
     }
 
     public function testWordBeginningWithYt()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("yttriaay", PigLatin::translate("yttria"));
+        $translator = new PigLatin();
+        $this->assertEquals("yttriaay", $translator->translate("yttria"));
     }
 
     public function testWordBeginningWithXr()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("xrayay", PigLatin::translate("xray"));
+        $translator = new PigLatin();
+        $this->assertEquals("xrayay", $translator->translate("xray"));
     }
 
     public function testAWholePhrase()
     {
         $this->markTestSkipped();
-
-        $this->assertEquals("ickquay astfay unray", PigLatin::translate("quick fast run"));
+        $translator = new PigLatin();
+        $this->assertEquals("ickquay astfay unray", $translator->translate("quick fast run"));
     }
 }

--- a/exercises/pig-latin/pig-latin_test.php
+++ b/exercises/pig-latin/pig-latin_test.php
@@ -3,79 +3,72 @@ require_once "pig-latin.php";
 
 class PigLatinTest extends PHPUnit_Framework_TestCase
 {
-    protected $translator = null;
-
-    public function setUp()
-    {
-        $this->translator = new PigLatin();
-    }
-
     public function testWordBeginningWithP()
     {
-        $this->assertEquals("igpay", $this->translator->translate("pig"));
+        $this->assertEquals("igpay", translate("pig"));
     }
 
     public function testWordBeginningWithK()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("oalakay", $this->translator->translate("koala"));
+        $this->assertEquals("oalakay", translate("koala"));
     }
 
     public function testWordBeginningWithY()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("ellowyay", $this->translator->translate("yellow"));
+        $this->assertEquals("ellowyay", translate("yellow"));
     }
 
     public function testWordBeginningWithX()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("enonxay", $this->translator->translate("xenon"));
+        $this->assertEquals("enonxay", translate("xenon"));
     }
 
     public function testWordBeginningWithA()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("appleay", $this->translator->translate("apple"));
+        $this->assertEquals("appleay", translate("apple"));
     }
 
     public function testWordBeginningWithE()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("earay", $this->translator->translate("ear"));
+        $this->assertEquals("earay", translate("ear"));
     }
 
     public function testWordBeginningWithI()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("iglooay", $this->translator->translate("igloo"));
+        $this->assertEquals("iglooay", translate("igloo"));
     }
 
     public function testWordBeginningWithO()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("objectay", $this->translator->translate("object"));
+        $this->assertEquals("objectay", translate("object"));
     }
 
     public function testWordBeginningWithU()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("underay", $this->translator->translate("under"));
+        $this->assertEquals("underay", translate("under"));
     }
 
     public function testWordBeginningVowelFollowedByQu()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("equalay", $this->translator->translate("equal"));
+        $this->assertEquals("equalay", translate("equal"));
     }
 
 
@@ -83,7 +76,7 @@ class PigLatinTest extends PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("atqay", $this->translator->translate("qat"));
+        $this->assertEquals("atqay", translate("qat"));
     }
 
 
@@ -91,62 +84,62 @@ class PigLatinTest extends PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("airchay", $this->translator->translate("chair"));
+        $this->assertEquals("airchay", translate("chair"));
     }
 
     public function testWordBeginningWithQu()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("eenquay", $this->translator->translate("queen"));
+        $this->assertEquals("eenquay", translate("queen"));
     }
 
     public function testWordBeginningWithQuAndAPrecedingConsonant()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("aresquay", $this->translator->translate("square"));
+        $this->assertEquals("aresquay", translate("square"));
     }
 
     public function testWordBeginningWithTh()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("erapythay", $this->translator->translate("therapy"));
+        $this->assertEquals("erapythay", translate("therapy"));
     }
 
     public function testWordBeginningWithThr()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("ushthray", $this->translator->translate("thrush"));
+        $this->assertEquals("ushthray", translate("thrush"));
     }
 
     public function testWordBeginningWithSch()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("oolschay", $this->translator->translate("school"));
+        $this->assertEquals("oolschay", translate("school"));
     }
 
     public function testWordBeginningWithYt()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("yttriaay", $this->translator->translate("yttria"));
+        $this->assertEquals("yttriaay", translate("yttria"));
     }
 
     public function testWordBeginningWithXr()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("xrayay", $this->translator->translate("xray"));
+        $this->assertEquals("xrayay", translate("xray"));
     }
 
     public function testAWholePhrase()
     {
         $this->markTestSkipped();
 
-        $this->assertEquals("ickquay astfay unray", $this->translator->translate("quick fast run"));
+        $this->assertEquals("ickquay astfay unray", translate("quick fast run"));
     }
 }


### PR DESCRIPTION
The tests will now properly instantiate classes instead of calling PigLatin::translate(); directly. This allows the usage of member variables etc. in solutions. I've also added a test case as proposed in another pull request to x-common to check for proper implementation of the consonant+qu rule.