### PR TITLE
Improvement for add help to makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
 - 7.0
 script:
+- make install
 - make style-check
 - make test
 - "./bin/fetch-configlet"

--- a/Makefile
+++ b/Makefile
@@ -12,32 +12,37 @@ FILEEXT := "php"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
-# development dependencies
-bin/phpunit.phar:
-	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O $@
-	chmod +x $@
+help: ## Prints this help.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-bin/phpcs.phar:
-	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O $@
-	chmod +x $@
+install: ## install development dependencies
+	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	chmod +x bin/phpunit.phar
 
-# single test
-test-assignment: bin/phpunit.phar
+	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
+	chmod +x bin/phpcs.phar
+
+install-test: ## install test dependency: phpunit.phar 
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	chmod +x bin/phpunit.phar
+
+install-phpcs: ## install style checker dependency: phpcs.pha
+	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
+	chmod +x bin/phpcs.phar
+
+test-assignment: bin/phpunit.phar ## single test using ASSGNMENT: test-assignment ASSIGNMENT=wordy
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cat ./exercises/$(ASSIGNMENT)/$(TSTFILE) | sed '/markTestSkipped()/d' > $(OUTDIR)/$(TSTFILE)
 	@cp ./exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@bin/phpunit.phar --no-configuration $(OUTDIR)/$(TSTFILE)
 
-# all tests
-test:
+test: ## all tests
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
 
-# style check single test
-style-check-assignment: bin/phpcs.phar
+style-check-assignment: bin/phpcs.phar ## style check single test using ASSGNMENT: style-check-assignment ASSIGNMENT=wordy
 	@echo "checking $(ASSIGNMENT) against xPHP code standards"
 	@bin/phpcs.phar -sp --standard=phpcs-xphp.xml ./exercises/$(ASSIGNMENT)
 
-# style c heck all tests
-style-check:
+style-check: ## style check all tests
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s style-check-assignment || exit 1; done
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ FILEEXT := "php"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
-help: ## Prints this help.
+help: ## Prints this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## install development dependencies
@@ -26,23 +26,23 @@ install-test: ## install test dependency: phpunit.phar
 	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
 	chmod +x bin/phpunit.phar
 
-install-phpcs: ## install style checker dependency: phpcs.pha
+install-style: ## install style checker dependency: phpcs.phar
 	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
-test-assignment: bin/phpunit.phar ## single test using ASSGNMENT: test-assignment ASSIGNMENT=wordy
+test-assignment: bin/phpunit.phar ## run single test using ASSGNMENT: test-assignment ASSIGNMENT=wordy
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cat ./exercises/$(ASSIGNMENT)/$(TSTFILE) | sed '/markTestSkipped()/d' > $(OUTDIR)/$(TSTFILE)
 	@cp ./exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@bin/phpunit.phar --no-configuration $(OUTDIR)/$(TSTFILE)
 
-test: ## all tests
+test: ## run all tests
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
 
-style-check-assignment: bin/phpcs.phar ## style check single test using ASSGNMENT: style-check-assignment ASSIGNMENT=wordy
+style-check-assignment: bin/phpcs.phar ## run style check single test using ASSGNMENT: style-check-assignment ASSIGNMENT=wordy
 	@echo "checking $(ASSIGNMENT) against xPHP code standards"
 	@bin/phpcs.phar -sp --standard=phpcs-xphp.xml ./exercises/$(ASSIGNMENT)
 
-style-check: ## style check all tests
+style-check: ## run style check all tests
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s style-check-assignment || exit 1; done
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ FILEEXT := "php"
 EXAMPLE := "example.$(FILEEXT)"
 TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
 
+default:
+	wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpunit.phar
+	chmod +x bin/phpunit.phar
+	@wget --no-check-certificate https://github.com/squizlabs/PHP_CodeSniffer/releases/download/2.0.0a2/phpcs.phar -O bin/phpcs.phar
+	chmod +x bin/phpcs.phar
+
 help: ## Prints this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install-style: ## install style checker dependency: phpcs.phar
 	@wget --no-check-certificate https://phar.phpunit.de/phpunit.phar -O bin/phpcs.phar
 	chmod +x bin/phpcs.phar
 
-test-assignment: bin/phpunit.phar ## run single test using ASSGNMENT: test-assignment ASSIGNMENT=wordy
+test-assignment: bin/phpunit.phar ## run single test using ASSIGNMENTS: test-assignment ASSIGNMENT=wordy
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cat ./exercises/$(ASSIGNMENT)/$(TSTFILE) | sed '/markTestSkipped()/d' > $(OUTDIR)/$(TSTFILE)
 	@cp ./exercises/$(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
@@ -39,7 +39,7 @@ test-assignment: bin/phpunit.phar ## run single test using ASSGNMENT: test-assig
 test: ## run all tests
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
 
-style-check-assignment: bin/phpcs.phar ## run style check single test using ASSGNMENT: style-check-assignment ASSIGNMENT=wordy
+style-check-assignment: bin/phpcs.phar ## run style check single test using ASSIGNMENTS: style-check-assignment ASSIGNMENT=wordy
 	@echo "checking $(ASSIGNMENT) against xPHP code standards"
 	@bin/phpcs.phar -sp --standard=phpcs-xphp.xml ./exercises/$(ASSIGNMENT)
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 Exercism exercises in PHP
 
+## Install Dependencies
+
+### All dependencies
+
+	% make install
+
+### Only tests dependencies
+
+	% make install-test
+
+### Only style-check dependencies
+
+	% make install-style
+
 ## Running Unit Test Suite
 
 ### All Assignments
@@ -23,6 +37,11 @@ Exercism exercises in PHP
 ### Single Assignment
 
     % make style-check-assignment ASSIGNMENT=wordy
+
+## Help
+If you need command line help for run make commands
+
+	% make
 
 ## Contributing
 


### PR DESCRIPTION
Now you have help messages when use `make` command in the terminal.

Example:
```
% make
help                 Prints this help
install              install development dependencies
install-test         install test dependency: phpunit.phar
install-style        install style checker dependency: phpcs.phar
test-assignment      run single test using ASSIGNMENT: test-assignment ASSIGNMENT=wordy
test                 run all tests
style-check-assignment run style check single test using ASSIGNMENT: style-check-assignment ASSIGNMENT=wordy
style-check          run style check all tests
```

EDIT:
I change travis config file. I added an initial step for download phpunit.phar and php-cs.phar