### PR TITLE
Variable-length-quantity: enhance testOverflow

### DIFF
--- a/exercises/variable-length-quantity/variable-length-quantity_test.php
+++ b/exercises/variable-length-quantity/variable-length-quantity_test.php
@@ -122,7 +122,7 @@ class VariableLengthQuantityTest extends PHPUnit_Framework_TestCase
 
         $this->setExpectedException(OverflowException::class);
 
-        vlq_decode([0xff, 0xff, 0xff, 0xff, 0xff]);
+        vlq_decode([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]);
     }
 
     public function testChainedDecodeEncodeGivesOriginalBytes()


### PR DESCRIPTION
1. 64-bit systems PHP_INT_MAX is 9223372036854775807. Check may be done against PHP_INT_MAX. Or the MAX possible outcome value should be outlined in the task description.
2. Encoded sequence should be completed with valid last item. Depending on realization validation of the last item may precede anything else and throw InvalidArgumentException(). Overflow and invalid input should not be mixed in one test.