### PR TITLE
Add Grains exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -307,6 +307,14 @@
     "slug": "markdown",
     "difficulty": 3,
     "topics": ["refactoring"]
+  },
+  {
+    "slug": "grains",
+    "difficulty": 3,
+    "topics": [
+      "Floating-point numbers",
+      "Algorithms"
+    ]
   }
   ]
 }

--- a/exercises/grains/example.php
+++ b/exercises/grains/example.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ *
+Here is the simplest solution. But King hates floats.
+
+function square($n)
+{
+    if ($n < 1 || $n > 64) {
+        throw new InvalidArgumentException();
+    }
+    return pow(2, $n - 1);
+}
+
+function total()
+{
+    return array_reduce(range(1, 64), function ($acc, $n) {
+        return $acc += square($n);
+    });
+}
+ */
+
+function square($n)
+{
+    if ($n < 1 || $n > 64) {
+        throw new InvalidArgumentException();
+    }
+
+    $result = [1];
+    for ($i = $n - 1; $i > 0; $i--) {
+        $result = sum($result, $result);
+    }
+
+    return implode('', array_reverse($result));
+}
+
+function total()
+{
+    return implode('', array_reverse(
+        array_reduce(range(1, 64), function ($acc, $n) {
+            return sum($acc, array_reverse(str_split(square($n))));
+        }, [])
+    ));
+}
+
+function sum($x, $y)
+{
+    $shift = 0;
+    $result = array_map(function ($a, $b) use (&$shift) {
+        $value = $a + $b + $shift;
+        if ($value >= 10) {
+            $value -= 10;
+            $shift = 1;
+        } else {
+            $shift = 0;
+        }
+        return $value;
+    }, $x, $y);
+    if ($shift) {
+        array_push($result, $shift);
+    }
+    return $result;
+}

--- a/exercises/grains/grains_test.php
+++ b/exercises/grains/grains_test.php
@@ -1,0 +1,82 @@
+<?php
+
+include_once 'grains.php';
+
+class GrainsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * PHP integers greater than 2^31 (32-bit systems)
+     * or 2^63 (64-bit) are casted to floats.
+     * In some cases it may lead to problems
+     * http://php.net/manual/ru/language.types.float.php#warn.float-precision
+     *
+     * Consider King hates floats and demands solution with
+     * precise integer-only calculations. Don't involve any floats.
+     * Don't use gmp or any other similar libraries.
+     * Try to make the solution for virtually any board size.
+     */
+
+    public function testInput1()
+    {
+        $this->assertSame('1', square(1));
+    }
+
+    public function testInput2()
+    {
+        $this->assertSame('2', square(2));
+    }
+
+    public function testInput3()
+    {
+        $this->assertSame('4', square(3));
+    }
+
+    public function testInput4()
+    {
+        $this->assertSame('8', square(4));
+    }
+
+    public function testInput16()
+    {
+        $this->assertSame('32768', square(16));
+    }
+
+    public function testInput32()
+    {
+        $this->assertSame('2147483648', square(32));
+    }
+
+    public function testInput64()
+    {
+        $this->assertSame('9223372036854775808', square(64));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRejectsZero()
+    {
+        square(0);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRejectsNegative()
+    {
+        square(-1);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRejectsGreaterThan64()
+    {
+        square(65);
+    }
+
+    public function testTotal()
+    {
+        $this->assertSame('18446744073709551615', total());
+    }
+}


### PR DESCRIPTION
I believe that the task may be set up a bit more interesting for the PHP implementation.
 
PHP integers greater than 2^31 (32-bit systems) or 2^63 (64-bit) are casted to floats. In some cases it may lead to problems:
* http://php.net/manual/ru/language.types.float.php#warn.float-precision

Consider King hates floats and demands solution with precise integer-only calculations. Don't involve any floats. Don't use gmp or any other similar libraries. Try to make the solution for virtually any board size.